### PR TITLE
Add alternate fail-fast implementation of RemoteData

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "typescript.tsdk": "node_modules/typescript/lib"
+}

--- a/src/__tests__/remote-data-io_.spec.ts
+++ b/src/__tests__/remote-data-io_.spec.ts
@@ -1,0 +1,39 @@
+import { createRemoteDataFromJSON } from '../remote-data-io_';
+import * as t from 'io-ts';
+import { initial, pending, failure, success, progress } from '../remote-data_';
+import { right } from 'fp-ts/lib/Either';
+import { none, some } from 'fp-ts/lib/Option';
+
+describe('RemoteDataFromJSONType', () => {
+	it('createRemoteDataFromJSON', () => {
+		const T = createRemoteDataFromJSON(t.string, t.number);
+		expect(T.decode({ type: 'Failure_', error: 'error' })).toEqual(right(failure('error')));
+		expect(T.decode({ type: 'Initial_' })).toEqual(right(initial));
+		expect(T.decode({ type: 'Pending_', progress: null })).toEqual(right(pending));
+		expect(T.decode({ type: 'Pending_', progress: { loaded: 2, total: null } })).toEqual(
+			right(progress({ loaded: 2, total: none })),
+		);
+		expect(T.decode({ type: 'Pending_', progress: { loaded: 2, total: 5 } })).toEqual(
+			right(progress({ loaded: 2, total: some(5) })),
+		);
+		expect(T.decode({ type: 'Success_', value: 42 })).toEqual(right(success(42)));
+		expect(T.encode(failure('error'))).toEqual({ type: 'Failure_', error: 'error' });
+		expect(T.encode(initial)).toEqual({ type: 'Initial_' });
+		expect(T.encode(pending)).toEqual({ type: 'Pending_', progress: null });
+		expect(T.encode(progress({ loaded: 2, total: none }))).toEqual({
+			type: 'Pending_',
+			progress: { loaded: 2, total: null },
+		});
+		expect(T.encode(progress({ loaded: 2, total: some(5) }))).toEqual({
+			type: 'Pending_',
+			progress: { loaded: 2, total: 5 },
+		});
+		expect(T.encode(success(42))).toEqual({ type: 'Success_', value: 42 });
+		expect(T.is(failure('error'))).toBe(true);
+		expect(T.is(initial)).toBe(true);
+		expect(T.is(pending)).toBe(true);
+		expect(T.is(success(42))).toBe(true);
+		expect(T.is(failure(1))).toBe(false);
+		expect(T.is(success('invalid'))).toBe(false);
+	});
+});

--- a/src/__tests__/remote-data_.spec.ts
+++ b/src/__tests__/remote-data_.spec.ts
@@ -1,0 +1,786 @@
+import {
+	pending,
+	failure,
+	success,
+	RemoteData_,
+	initial,
+	combine,
+	remoteData,
+	getSetoid,
+	getOrd,
+	getSemigroup,
+	getMonoid,
+	fromOption,
+	fromEither,
+	fromPredicate,
+	progress,
+	fromProgressEvent,
+} from '../remote-data_';
+import { identity, compose, Function1 } from 'fp-ts/lib/function';
+import { sequence, traverse } from 'fp-ts/lib/Traversable';
+import { none, option, some } from 'fp-ts/lib/Option';
+import { array } from 'fp-ts/lib/Array';
+import { setoidNumber, setoidString } from 'fp-ts/lib/Setoid';
+import { ordNumber, ordString } from 'fp-ts/lib/Ord';
+import { semigroupString, semigroupSum } from 'fp-ts/lib/Semigroup';
+import { monoidString, monoidSum } from 'fp-ts/lib/Monoid';
+import { left, right } from 'fp-ts/lib/Either';
+
+describe('RemoteData_', () => {
+	const double = (x: number) => x * 2;
+	const initialRD: RemoteData_<string, number> = initial;
+	const pendingRD: RemoteData_<string, number> = pending;
+	const successRD: RemoteData_<string, number> = success(1);
+	const failureRD: RemoteData_<string, number> = failure('foo');
+	const progressRD: RemoteData_<string, Function1<number, number>> = progress({ loaded: 1, total: none });
+	describe('Functor', () => {
+		describe('should map over value', () => {
+			it('initial', () => {
+				expect(initial.map(double)).toBe(initial);
+			});
+			it('pending', () => {
+				expect(pending.map(double)).toBe(pending);
+			});
+			it('failure', () => {
+				const failed = failure<string, number>('foo');
+				expect(failed.map(double)).toBe(failed);
+			});
+			it('success', () => {
+				const value = 123;
+				const succeeded = success(value);
+				const result = succeeded.map(double);
+				expect(result).toEqual(success(value * 2));
+			});
+		});
+		describe('laws', () => {
+			describe('identity', () => {
+				it('initial', () => {
+					expect(initial.map(identity)).toBe(initial);
+				});
+				it('pending', () => {
+					expect(pending.map(identity)).toBe(pending);
+				});
+				it('failure', () => {
+					const failed = failure('foo');
+					expect(failed.map(identity)).toBe(failed);
+				});
+				it('success', () => {
+					const succeeded = success('foo');
+					const result = succeeded.map(identity);
+					expect(result).toEqual(succeeded);
+					expect(result).not.toBe(succeeded);
+				});
+			});
+			describe('composition', () => {
+				const double = (a: number): number => a * 2;
+				const quad = compose(double, double);
+				it('initial', () => {
+					expect(initial.map(quad)).toBe(initial.map(double).map(double));
+				});
+				it('pending', () => {
+					expect(pending.map(quad)).toBe(pending.map(double).map(double));
+				});
+				it('failure', () => {
+					const failed: RemoteData_<string, number> = failure('foo');
+					expect(failed.map(quad)).toBe(failed.map(double).map(double));
+				});
+				it('success', () => {
+					const value = 1;
+					const succeeded = success(value);
+					expect(succeeded.map(quad)).toEqual(success(quad(value)));
+				});
+			});
+		});
+	});
+	describe('Alt', () => {
+		describe('should alt', () => {
+			it('initial', () => {
+				expect(initialRD.alt(initialRD)).toBe(initialRD);
+				expect(initialRD.alt(pendingRD)).toBe(pendingRD);
+				expect(initialRD.alt(failureRD)).toBe(failureRD);
+				expect(initialRD.alt(successRD)).toBe(successRD);
+			});
+			it('pending', () => {
+				expect(pendingRD.alt(initialRD)).toBe(initialRD);
+				expect(pendingRD.alt(pendingRD)).toBe(pendingRD);
+				expect(pendingRD.alt(failureRD)).toBe(failureRD);
+				expect(pendingRD.alt(successRD)).toBe(successRD);
+			});
+			it('failure', () => {
+				expect(failureRD.alt(pendingRD)).toBe(pendingRD);
+				expect(failureRD.alt(initialRD)).toBe(initialRD);
+				expect(failureRD.alt(failureRD)).toBe(failureRD);
+				expect(failureRD.alt(successRD)).toBe(successRD);
+			});
+			it('failure', () => {
+				expect(successRD.alt(pendingRD)).toBe(successRD);
+				expect(successRD.alt(initialRD)).toBe(successRD);
+				expect(successRD.alt(failureRD)).toBe(successRD);
+				expect(successRD.alt(successRD)).toBe(successRD);
+			});
+		});
+	});
+	describe('Apply', () => {
+		describe('should ap', () => {
+			const f: RemoteData_<string, (a: number) => number> = success(double);
+			const failedF: RemoteData_<string, (a: number) => number> = failure('foo');
+			it('initial', () => {
+				expect(initialRD.ap(initial)).toBe(initialRD);
+				expect(initialRD.ap(pending)).toBe(initialRD);
+				expect(initialRD.ap(progressRD)).toBe(initialRD);
+				expect(initialRD.ap(failedF)).toBe(failedF);
+				expect(initialRD.ap(f)).toBe(initialRD);
+			});
+			it('pending', () => {
+				expect(pendingRD.ap(initial)).toBe(initial);
+				expect(pendingRD.ap(pending)).toBe(pendingRD);
+				expect(pendingRD.ap(progressRD)).toBe(progressRD);
+				expect(pendingRD.ap(failedF)).toBe(failedF);
+				expect(pendingRD.ap(f)).toBe(pendingRD);
+			});
+			it('failure', () => {
+				expect(failureRD.ap(initial)).toBe(failureRD);
+				expect(failureRD.ap(pending)).toBe(failureRD);
+				expect(failureRD.ap(progressRD)).toBe(failureRD);
+				expect(failureRD.ap(failedF)).toBe(failedF);
+				expect(failureRD.ap(f)).toBe(failureRD);
+			});
+			it('success', () => {
+				expect(successRD.ap(initial)).toBe(initial);
+				expect(successRD.ap(pending)).toBe(pending);
+				expect(successRD.ap(progressRD)).toBe(progressRD);
+				expect(successRD.ap(failedF)).toBe(failedF);
+				expect(successRD.ap(f)).toEqual(success(double(1)));
+			});
+		});
+	});
+	describe('Applicative', () => {
+		describe('sequence', () => {
+			const s = sequence(remoteData, array);
+			it('initial', () => {
+				expect(s([initialRD, successRD])).toBe(initialRD);
+			});
+			it('pending', () => {
+				expect(s([pendingRD, successRD])).toBe(pendingRD);
+			});
+			it('failure', () => {
+				expect(s([failureRD, successRD])).toBe(failureRD);
+			});
+			it('success', () => {
+				expect(s([success(123), success(456)])).toEqual(success([123, 456]));
+			});
+		});
+	});
+	describe('Chain', () => {
+		describe('chain', () => {
+			it('initial', () => {
+				expect(initialRD.chain(() => initialRD)).toBe(initialRD);
+				expect(initialRD.chain(() => pendingRD)).toBe(initialRD);
+				expect(initialRD.chain(() => failureRD)).toBe(initialRD);
+				expect(initialRD.chain(() => successRD)).toBe(initialRD);
+			});
+			it('pending', () => {
+				expect(pendingRD.chain(() => initialRD)).toBe(pendingRD);
+				expect(pendingRD.chain(() => pendingRD)).toBe(pendingRD);
+				expect(pendingRD.chain(() => failureRD)).toBe(pendingRD);
+				expect(pendingRD.chain(() => successRD)).toBe(pendingRD);
+			});
+			it('failure', () => {
+				expect(failureRD.chain(() => initialRD)).toBe(failureRD);
+				expect(failureRD.chain(() => pendingRD)).toBe(failureRD);
+				expect(failureRD.chain(() => failureRD)).toBe(failureRD);
+				expect(failureRD.chain(() => successRD)).toBe(failureRD);
+			});
+			it('success', () => {
+				expect(successRD.chain(() => initialRD)).toBe(initialRD);
+				expect(successRD.chain(() => pendingRD)).toBe(pendingRD);
+				expect(successRD.chain(() => failureRD)).toBe(failureRD);
+				expect(successRD.chain(() => successRD)).toBe(successRD);
+			});
+		});
+	});
+	describe('Extend', () => {
+		describe('extend', () => {
+			const f = () => 1;
+			it('initial', () => {
+				expect(initialRD.extend(f)).toBe(initialRD);
+			});
+			it('pending', () => {
+				expect(pendingRD.extend(f)).toBe(pendingRD);
+			});
+			it('failure', () => {
+				expect(failureRD.extend(f)).toBe(failureRD);
+			});
+			it('pending', () => {
+				expect(successRD.extend(f)).toEqual(success(1));
+			});
+		});
+	});
+	describe('Traversable', () => {
+		describe('traverse', () => {
+			const t = traverse(option, remoteData);
+			const f = (x: number) => (x >= 2 ? some(x) : none);
+			it('initial', () => {
+				expect(t(initialRD, f)).toEqual(some(initialRD));
+			});
+			it('pending', () => {
+				expect(t(pendingRD, f)).toEqual(some(pendingRD));
+			});
+			it('failure', () => {
+				expect(t(failureRD, f)).toEqual(some(failureRD));
+			});
+			it('success', () => {
+				expect(t(success(1), f)).toBe(none);
+				expect(t(success(3), f)).toEqual(some(success(3)));
+			});
+		});
+	});
+	describe('Foldable', () => {
+		describe('reduce', () => {
+			const f = (a: number, b: number) => a + b;
+			it('initial', () => {
+				expect(initialRD.reduce(f, 1)).toBe(1);
+			});
+			it('pending', () => {
+				expect(pendingRD.reduce(f, 1)).toBe(1);
+			});
+			it('failure', () => {
+				expect(failureRD.reduce(f, 1)).toBe(1);
+			});
+			it('failure', () => {
+				expect(success(1).reduce(f, 1)).toBe(2);
+			});
+		});
+	});
+	describe('Alternative', () => {
+		it('zero', () => {
+			expect(remoteData.zero()).toBe(initial);
+		});
+	});
+	describe('Setoid', () => {
+		describe('getSetoid', () => {
+			const equals = getSetoid(setoidString, setoidNumber).equals;
+			it('initial', () => {
+				expect(equals(initialRD, initialRD)).toBe(true);
+				expect(equals(initialRD, pendingRD)).toBe(false);
+				expect(equals(initialRD, failureRD)).toBe(false);
+				expect(equals(initialRD, successRD)).toBe(false);
+			});
+			it('pending', () => {
+				expect(equals(pendingRD, initialRD)).toBe(false);
+				expect(equals(pendingRD, pendingRD)).toBe(true);
+				expect(equals(pendingRD, failureRD)).toBe(false);
+				expect(equals(pendingRD, successRD)).toBe(false);
+			});
+			it('failure', () => {
+				expect(equals(failureRD, initialRD)).toBe(false);
+				expect(equals(failureRD, pendingRD)).toBe(false);
+				expect(equals(failureRD, failureRD)).toBe(true);
+				expect(equals(failure('1'), failure('2'))).toBe(false);
+				expect(equals(failureRD, successRD)).toBe(false);
+			});
+			it('success', () => {
+				expect(equals(successRD, initialRD)).toBe(false);
+				expect(equals(successRD, pendingRD)).toBe(false);
+				expect(equals(successRD, failureRD)).toBe(false);
+				expect(equals(successRD, successRD)).toBe(true);
+				expect(equals(success(1), success(2))).toBe(false);
+			});
+		});
+	});
+	describe('Ord', () => {
+		describe('getOrd', () => {
+			const compare = getOrd(ordString, ordNumber).compare;
+			it('initial', () => {
+				expect(compare(initialRD, initialRD)).toBe(0);
+				expect(compare(initialRD, pendingRD)).toBe(-1);
+				expect(compare(initialRD, failureRD)).toBe(-1);
+				expect(compare(initialRD, successRD)).toBe(-1);
+			});
+			it('pending', () => {
+				expect(compare(pendingRD, initialRD)).toBe(1);
+				expect(compare(pendingRD, pendingRD)).toBe(0);
+				expect(compare(pendingRD, failureRD)).toBe(-1);
+				expect(compare(pendingRD, successRD)).toBe(-1);
+			});
+			it('failure', () => {
+				expect(compare(failureRD, initialRD)).toBe(1);
+				expect(compare(failureRD, pendingRD)).toBe(1);
+				expect(compare(failureRD, failureRD)).toBe(0);
+				expect(compare(failureRD, successRD)).toBe(-1);
+				expect(compare(failure('1'), failure('2'))).toBe(-1);
+				expect(compare(failure('2'), failure('1'))).toBe(1);
+			});
+			it('success', () => {
+				expect(compare(successRD, initialRD)).toBe(1);
+				expect(compare(successRD, pendingRD)).toBe(1);
+				expect(compare(successRD, failureRD)).toBe(1);
+				expect(compare(successRD, successRD)).toBe(0);
+				expect(compare(success(1), success(2))).toBe(-1);
+				expect(compare(success(2), success(1))).toBe(1);
+			});
+		});
+	});
+	describe('Semigroup', () => {
+		describe('getSemigroup', () => {
+			const concat = getSemigroup(semigroupString, semigroupSum).concat;
+			it('initial', () => {
+				expect(concat(initialRD, initialRD)).toBe(initialRD);
+				expect(concat(initialRD, pendingRD)).toBe(pendingRD);
+				expect(concat(initialRD, failureRD)).toBe(failureRD);
+				expect(concat(initialRD, successRD)).toBe(successRD);
+			});
+			it('pending', () => {
+				expect(concat(pendingRD, initialRD)).toBe(pendingRD);
+				expect(concat(pendingRD, pendingRD)).toBe(pendingRD);
+				expect(concat(pendingRD, failureRD)).toBe(failureRD);
+				expect(concat(pendingRD, successRD)).toBe(successRD);
+			});
+			it('failure', () => {
+				expect(concat(failureRD, initialRD)).toBe(failureRD);
+				expect(concat(failureRD, pendingRD)).toBe(failureRD);
+				expect(concat(failure('foo'), failure('bar'))).toEqual(failure(semigroupString.concat('foo', 'bar')));
+				expect(concat(failureRD, successRD)).toBe(successRD);
+			});
+			it('success', () => {
+				expect(concat(successRD, initialRD)).toBe(successRD);
+				expect(concat(successRD, pendingRD)).toBe(successRD);
+				expect(concat(successRD, failureRD)).toBe(successRD);
+				expect(concat(success(1), success(1))).toEqual(success(semigroupSum.concat(1, 1)));
+			});
+			describe('progress', () => {
+				it('should concat pendings without progress', () => {
+					expect(concat(pending, pending)).toEqual(pending);
+				});
+				it('should concat pending and progress', () => {
+					const withProgress: RemoteData_<string, number> = progress({ loaded: 1, total: none });
+					expect(concat(pending, withProgress)).toBe(withProgress);
+				});
+				it('should concat progress without total', () => {
+					const withProgress: RemoteData_<string, number> = progress({ loaded: 1, total: none });
+					expect(concat(withProgress, withProgress)).toEqual(progress({ loaded: 2, total: none }));
+				});
+				it('should concat progress without total and progress with total', () => {
+					const withProgress: RemoteData_<string, number> = progress({ loaded: 1, total: none });
+					const withProgressAndTotal: RemoteData_<string, number> = progress({ loaded: 1, total: some(2) });
+					expect(concat(withProgress, withProgressAndTotal)).toEqual(progress({ loaded: 2, total: none }));
+				});
+				it('should combine progresses with total', () => {
+					const expected = progress({
+						loaded: (2 * 10 + 2 * 30) / (40 * 40),
+						total: some(10 + 30),
+					});
+					expect(
+						concat(progress({ loaded: 2, total: some(10) }), progress({ loaded: 2, total: some(30) })),
+					).toEqual(expected);
+				});
+			});
+		});
+	});
+	describe('Monoid', () => {
+		it('getMonoid', () => {
+			const empty = getMonoid(monoidString, monoidSum).empty;
+			expect(empty).toBe(initial);
+		});
+	});
+	describe('helpers', () => {
+		describe('combine', () => {
+			it('should combine all initials to initial', () => {
+				expect(combine(initial, initial)).toBe(initial);
+			});
+			it('should combine all pendings to pending', () => {
+				expect(combine(pending, pending)).toBe(pending);
+			});
+			it('should combine all failures to first failure', () => {
+				expect(combine(failure('foo'), failure('bar'))).toEqual(failure('foo'));
+			});
+			it('should combine all successes to success of list of values', () => {
+				expect(combine(success('foo'), success('bar'))).toEqual(success(['foo', 'bar']));
+			});
+			it('should combine arbitrary values to first initial', () => {
+				const values = [success(123), success('foo'), initial, pending];
+				expect(combine.apply(null, values)).toEqual(initial);
+				expect(combine.apply(null, values.reverse())).toEqual(initial);
+			});
+			it('should combine arbitrary values to first pending', () => {
+				const values = [success(123), success('foo'), pending];
+				expect(combine.apply(null, values)).toBe(pending);
+				expect(combine.apply(null, values.reverse())).toBe(pending);
+			});
+			it('should combine arbitrary values to first failure', () => {
+				const failureRD_ = failure('bar');
+				const values = [success(123), success('foo'), failureRD_, pending, initial];
+				expect(combine.apply(null, values)).toBe(failureRD_);
+				expect(combine.apply(null, values.reverse())).toBe(failureRD_);
+			});
+			describe('progress', () => {
+				it('should combine pendings without progress', () => {
+					const values = [pending, pending];
+					expect(combine.apply(null, values)).toBe(pending);
+					expect(combine.apply(null, values.reverse())).toBe(pending);
+				});
+				it('should combine pending and progress', () => {
+					const withProgress = progress({ loaded: 1, total: none });
+					const values = [pending, withProgress];
+					expect(combine.apply(null, values)).toBe(withProgress);
+					expect(combine.apply(null, values.reverse())).toBe(withProgress);
+				});
+				it('should combine progress without total', () => {
+					const withProgress = progress({ loaded: 1, total: none });
+					const values = [withProgress, withProgress];
+					expect(combine.apply(null, values)).toEqual(progress({ loaded: 2, total: none }));
+					expect(combine.apply(null, values.reverse())).toEqual(progress({ loaded: 2, total: none }));
+				});
+				it('should combine progress without total and progress with total', () => {
+					const withProgress = progress({ loaded: 1, total: none });
+					const withProgressAndTotal = progress({ loaded: 1, total: some(2) });
+					const values = [withProgress, withProgressAndTotal];
+					expect(combine.apply(null, values)).toEqual(progress({ loaded: 2, total: none }));
+					expect(combine.apply(null, values.reverse())).toEqual(progress({ loaded: 2, total: none }));
+				});
+				it('should combine progresses with total', () => {
+					const values = [progress({ loaded: 2, total: some(10) }), progress({ loaded: 2, total: some(30) })];
+					const expected = progress({
+						loaded: (2 * 10 + 2 * 30) / (40 * 40),
+						total: some(10 + 30),
+					});
+					expect(combine.apply(null, values)).toEqual(expected);
+					expect(combine.apply(null, values.reverse())).toEqual(expected);
+				});
+			});
+		});
+		describe('fromOption', () => {
+			const error = new Error('foo');
+			it('none', () => {
+				expect(fromOption(none, () => error)).toEqual(failure(error));
+			});
+			it('some', () => {
+				expect(fromOption(some(123), () => error)).toEqual(success(123));
+			});
+		});
+		describe('fromEither', () => {
+			it('left', () => {
+				expect(fromEither(left('123'))).toEqual(failure('123'));
+			});
+			it('right', () => {
+				expect(fromEither(right('123'))).toEqual(success('123'));
+			});
+		});
+		describe('fromPredicate', () => {
+			const factory = fromPredicate((value: boolean) => value, () => '123');
+			it('false', () => {
+				expect(factory(false)).toEqual(failure('123'));
+			});
+			it('true', () => {
+				expect(factory(true)).toEqual(success(true));
+			});
+		});
+		describe('fromProgressEvent', () => {
+			const e = new ProgressEvent('test');
+			it('lengthComputable === false', () => {
+				expect(fromProgressEvent({ ...e, loaded: 123 })).toEqual(progress({ loaded: 123, total: none }));
+			});
+			it('lengthComputable === true', () => {
+				expect(fromProgressEvent({ ...e, loaded: 123, lengthComputable: true, total: 1000 })).toEqual(
+					progress({ loaded: 123, total: some(1000) }),
+				);
+			});
+		});
+	});
+	describe('instance methods', () => {
+		describe('getOrElse', () => {
+			it('initial', () => {
+				expect(initialRD.getOrElse(0)).toBe(0);
+			});
+			it('pending', () => {
+				expect(pendingRD.getOrElse(0)).toBe(0);
+			});
+			it('failure', () => {
+				expect(failureRD.getOrElse(0)).toBe(0);
+			});
+			it('success', () => {
+				expect(success(1).getOrElse(0)).toBe(1);
+			});
+		});
+		describe('getOrElseL', () => {
+			it('initial', () => {
+				expect(initialRD.getOrElseL(() => 0)).toBe(0);
+			});
+			it('pending', () => {
+				expect(pendingRD.getOrElseL(() => 0)).toBe(0);
+			});
+			it('failure', () => {
+				expect(failureRD.getOrElseL(() => 0)).toBe(0);
+			});
+			it('success', () => {
+				expect(success(1).getOrElseL(() => 0)).toBe(1);
+			});
+		});
+		describe('fold', () => {
+			it('initial', () => {
+				expect(initialRD.fold(1, 2, () => 3, () => 4)).toBe(1);
+			});
+			it('pending', () => {
+				expect(pendingRD.fold(1, 2, () => 3, () => 4)).toBe(2);
+			});
+			it('failure', () => {
+				expect(failureRD.fold(1, 2, () => 3, () => 4)).toBe(3);
+			});
+			it('success', () => {
+				expect(successRD.fold(1, 2, () => 3, () => 4)).toBe(4);
+			});
+		});
+		describe('foldL', () => {
+			it('initial', () => {
+				expect(initialRD.foldL(() => 1, () => 2, () => 3, () => 4)).toBe(1);
+			});
+			it('pending', () => {
+				expect(pendingRD.foldL(() => 1, () => 2, () => 3, () => 4)).toBe(2);
+			});
+			it('failure', () => {
+				expect(failureRD.foldL(() => 1, () => 2, () => 3, () => 4)).toBe(3);
+			});
+			it('success', () => {
+				expect(successRD.foldL(() => 1, () => 2, () => 3, () => 4)).toBe(4);
+			});
+		});
+		describe('altL', () => {
+			it('initial', () => {
+				expect(initialRD.altL(() => initialRD)).toBe(initialRD);
+				expect(initialRD.altL(() => pendingRD)).toBe(pendingRD);
+				expect(initialRD.altL(() => failureRD)).toBe(failureRD);
+				expect(initialRD.altL(() => successRD)).toBe(successRD);
+			});
+			it('pending', () => {
+				expect(pendingRD.altL(() => initialRD)).toBe(initialRD);
+				expect(pendingRD.altL(() => pendingRD)).toBe(pendingRD);
+				expect(pendingRD.altL(() => failureRD)).toBe(failureRD);
+				expect(pendingRD.altL(() => successRD)).toBe(successRD);
+			});
+			it('failure', () => {
+				expect(failureRD.altL(() => pendingRD)).toBe(pendingRD);
+				expect(failureRD.altL(() => initialRD)).toBe(initialRD);
+				expect(failureRD.altL(() => failureRD)).toBe(failureRD);
+				expect(failureRD.altL(() => successRD)).toBe(successRD);
+			});
+			it('failure', () => {
+				expect(successRD.altL(() => pendingRD)).toBe(successRD);
+				expect(successRD.altL(() => initialRD)).toBe(successRD);
+				expect(successRD.altL(() => failureRD)).toBe(successRD);
+				expect(successRD.altL(() => successRD)).toBe(successRD);
+			});
+		});
+		describe('mapLeft', () => {
+			const f2 = () => 1;
+			it('initial', () => {
+				expect(initialRD.mapLeft(f2)).toBe(initialRD);
+			});
+			it('pending', () => {
+				expect(pendingRD.mapLeft(f2)).toBe(pendingRD);
+			});
+			it('failure', () => {
+				expect(failureRD.mapLeft(f2)).toEqual(failure(1));
+			});
+			it('success', () => {
+				expect(successRD.mapLeft(f2)).toBe(successRD);
+			});
+		});
+		describe('isInitial', () => {
+			it('initial', () => {
+				expect(initialRD.isInitial()).toBe(true);
+			});
+			it('pending', () => {
+				expect(pendingRD.isInitial()).toBe(false);
+			});
+			it('failure', () => {
+				expect(failureRD.isInitial()).toEqual(false);
+			});
+			it('success', () => {
+				expect(successRD.isInitial()).toBe(false);
+			});
+		});
+		describe('isPending', () => {
+			it('initial', () => {
+				expect(initialRD.isPending()).toBe(false);
+			});
+			it('pending', () => {
+				expect(pendingRD.isPending()).toBe(true);
+			});
+			it('failure', () => {
+				expect(failureRD.isPending()).toEqual(false);
+			});
+			it('success', () => {
+				expect(successRD.isPending()).toBe(false);
+			});
+		});
+		describe('isFailure', () => {
+			it('initial', () => {
+				expect(initialRD.isFailure()).toBe(false);
+			});
+			it('pending', () => {
+				expect(pendingRD.isFailure()).toBe(false);
+			});
+			it('failure', () => {
+				expect(failureRD.isFailure()).toEqual(true);
+				if (failureRD.isFailure()) {
+					expect(failureRD.error).toBeDefined();
+				}
+			});
+			it('success', () => {
+				expect(successRD.isFailure()).toBe(false);
+			});
+		});
+		describe('isSuccess', () => {
+			it('initial', () => {
+				expect(initialRD.isSuccess()).toBe(false);
+			});
+			it('pending', () => {
+				expect(pendingRD.isSuccess()).toBe(false);
+			});
+			it('failure', () => {
+				expect(failureRD.isSuccess()).toEqual(false);
+			});
+			it('success', () => {
+				expect(successRD.isSuccess()).toBe(true);
+				if (successRD.isSuccess()) {
+					expect(successRD.value).toBeDefined();
+				}
+			});
+		});
+		describe('toOption', () => {
+			it('initial', () => {
+				expect(initialRD.toOption()).toBe(none);
+			});
+			it('pending', () => {
+				expect(pendingRD.toOption()).toBe(none);
+			});
+			it('failure', () => {
+				expect(failureRD.toOption()).toBe(none);
+			});
+			it('success', () => {
+				expect(success(1).toOption()).toEqual(some(1));
+			});
+		});
+		describe('toEither', () => {
+			it('initial', () => {
+				expect(initialRD.toEither('initial', 'pending')).toEqual(left('initial'));
+			});
+			it('pending', () => {
+				expect(pendingRD.toEither('initial', 'pending')).toEqual(left('pending'));
+			});
+			it('failure', () => {
+				expect(failureRD.toEither('initial', 'pending')).toEqual(left('foo'));
+			});
+			it('success', () => {
+				expect(success(1).toEither('initial', 'pending')).toEqual(right(1));
+			});
+		});
+		describe('toEitherL', () => {
+			const initialL = () => 'initial';
+			const pendingL = () => 'pending';
+
+			it('initial', () => {
+				expect(initialRD.toEitherL(initialL, pendingL)).toEqual(left('initial'));
+			});
+			it('pending', () => {
+				expect(pendingRD.toEitherL(initialL, pendingL)).toEqual(left('pending'));
+			});
+			it('failure', () => {
+				expect(failureRD.toEitherL(initialL, pendingL)).toEqual(left('foo'));
+			});
+			it('success', () => {
+				expect(success(1).toEitherL(initialL, pendingL)).toEqual(right(1));
+			});
+		});
+		describe('toNullable', () => {
+			it('initial', () => {
+				expect(initialRD.toNullable()).toBe(null);
+			});
+			it('pending', () => {
+				expect(pendingRD.toNullable()).toBe(null);
+			});
+			it('failure', () => {
+				expect(failureRD.toNullable()).toBe(null);
+			});
+			it('success', () => {
+				expect(success(1).toNullable()).toEqual(1);
+			});
+		});
+		describe('toString', () => {
+			it('initial', () => {
+				expect(initialRD.toString()).toBe('initial');
+			});
+			it('pending', () => {
+				expect(pendingRD.toString()).toBe('pending');
+			});
+			it('failure', () => {
+				expect(failure('foo').toString()).toBe('failure("foo")');
+			});
+			it('success', () => {
+				expect(success(1).toString()).toBe('success(1)');
+			});
+		});
+		describe('contains', () => {
+			it('initial', () => {
+				expect(initialRD.contains(setoidNumber, 1)).toBe(false);
+			});
+			it('pending', () => {
+				expect(pendingRD.contains(setoidNumber, 1)).toBe(false);
+			});
+			it('failure', () => {
+				expect(failureRD.contains(setoidNumber, 1)).toBe(false);
+			});
+			it('success', () => {
+				expect(success(2).contains(setoidNumber, 1)).toBe(false);
+				expect(success(1).contains(setoidNumber, 1)).toBe(true);
+			});
+		});
+		describe('exists', () => {
+			const p = (n: number) => n === 1;
+			it('initial', () => {
+				expect(initialRD.exists(p)).toBe(false);
+			});
+			it('pending', () => {
+				expect(pendingRD.exists(p)).toBe(false);
+			});
+			it('failure', () => {
+				expect(failureRD.exists(p)).toBe(false);
+			});
+			it('success', () => {
+				expect(success(2).exists(p)).toBe(false);
+				expect(success(1).exists(p)).toBe(true);
+			});
+		});
+		describe('recover', () => {
+			const f = (error: string) => (error === 'foo' ? some(1) : none);
+			it('initial', () => {
+				expect(initialRD.recover(f)).toBe(initialRD);
+			});
+			it('pending', () => {
+				expect(pendingRD.recover(f)).toBe(pendingRD);
+			});
+			it('failure', () => {
+				expect(failure<string, number>('foo').recover(f)).toEqual(success(1));
+			});
+			it('success', () => {
+				expect(successRD.recover(f)).toBe(successRD);
+			});
+		});
+		describe('recoverMap', () => {
+			const f = (error: string) => (error === 'foo' ? some(true) : none);
+			const isOdd = (n: number) => n % 2 === 0;
+			it('initial', () => {
+				expect(initialRD.recoverMap(f, isOdd)).toBe(initialRD);
+			});
+			it('pending', () => {
+				expect(pendingRD.recoverMap(f, isOdd)).toBe(pendingRD);
+			});
+			it('failure', () => {
+				expect(failure<string, number>('foo').recoverMap(f, isOdd)).toEqual(success(true));
+			});
+			it('success', () => {
+				expect(successRD.recoverMap(f, isOdd)).toEqual(success(false));
+			});
+		});
+	});
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,7 @@
 export * from './remote-data';
 export * from './remote-data-io';
+
+import * as remote_data_ from './remote-data_';
+import * as remote_data_io_ from './remote-data-io_';
+
+export { remote_data_, remote_data_io_ };

--- a/src/remote-data-io_.ts
+++ b/src/remote-data-io_.ts
@@ -1,0 +1,132 @@
+import * as t from 'io-ts';
+import { createOptionFromNullable } from 'io-ts-types';
+
+import {
+	failure,
+	initial,
+	pending,
+	RemoteData_,
+	RemoteFailure_,
+	RemoteInitial_,
+	RemotePending_,
+	RemoteSuccess_,
+	success,
+	RemoteProgress_,
+	progress,
+} from './remote-data_';
+
+//tslint:disable-next-line class-name
+export interface JSONFailure_<L> {
+	type: 'Failure_';
+	error: L;
+}
+
+//tslint:disable-next-line class-name
+export interface JSONInitial_ {
+	type: 'Initial_';
+}
+
+//tslint:disable-next-line class-name
+export interface JSONPending_ {
+	type: 'Pending_';
+	progress: RemoteProgress_ | null;
+}
+
+//tslint:disable-next-line class-name
+export interface JSONSuccess_<A> {
+	type: 'Success_';
+	value: A;
+}
+
+//tslint:disable-next-line class-name
+export type JSONRemoteData_<L, A> = JSONFailure_<L> | JSONInitial_ | JSONPending_ | JSONSuccess_<A>;
+
+//tslint:disable-next-line class-name
+export class RemoteDataFromJSONType_<L extends t.Any, R extends t.Any, A = any, O = A, I = t.mixed> extends t.Type<
+	A,
+	O,
+	I
+> {
+	readonly _tag: 'RemoteDataFromJSONType_' = 'RemoteDataFromJSONType_';
+	constructor(
+		name: string,
+		is: RemoteDataFromJSONType_<L, R, A, O, I>['is'],
+		validate: RemoteDataFromJSONType_<L, R, A, O, I>['validate'],
+		serialize: RemoteDataFromJSONType_<L, R, A, O, I>['encode'],
+		readonly left: L,
+		readonly right: R,
+	) {
+		super(name, is, validate, serialize);
+	}
+}
+
+export function createRemoteDataFromJSON<
+	L extends t.Type<AL, OL>,
+	R extends t.Type<AR, OR>,
+	AL = t.TypeOf<L>,
+	OL = t.OutputOf<L>,
+	AR = t.TypeOf<R>,
+	OR = t.OutputOf<R>
+>(
+	leftType: L,
+	rightType: R,
+	name: string = `RemoteData_<${leftType.name}, ${rightType.name}>`,
+): RemoteDataFromJSONType_<L, R, RemoteData_<AL, AR>, JSONRemoteData_<OL, OR>, t.mixed> {
+	const JSONProgress = createOptionFromNullable(
+		t.type({
+			loaded: t.number,
+			total: createOptionFromNullable(t.number),
+		}),
+	);
+	const JSONFailure = t.type({
+		type: t.literal('Failure_'),
+		error: leftType,
+	});
+	const JSONInitial = t.type({
+		type: t.literal('Initial_'),
+	});
+	const JSONPending = t.type({
+		type: t.literal('Pending_'),
+		progress: JSONProgress,
+	});
+	const JSONSuccess = t.type({
+		type: t.literal('Success_'),
+		value: rightType,
+	});
+	const JSONRemoteData = t.taggedUnion('type', [JSONFailure, JSONInitial, JSONPending, JSONSuccess]);
+	return new RemoteDataFromJSONType_(
+		name,
+		(m): m is RemoteData_<AL, AR> =>
+			m instanceof RemoteInitial_ ||
+			m instanceof RemotePending_ ||
+			(m instanceof RemoteFailure_ && leftType.is(m.error)) ||
+			(m instanceof RemoteSuccess_ && rightType.is(m.value)),
+		(m, c) => {
+			const validation = JSONRemoteData.validate(m, c);
+			if (validation.isLeft()) {
+				return validation as any;
+			} else {
+				const e = validation.value;
+				switch (e.type) {
+					case 'Failure_':
+						return t.success(failure(e.error));
+					case 'Initial_':
+						return t.success(initial);
+					case 'Pending_':
+						return e.progress.foldL(() => t.success(pending), p => t.success(progress(p)));
+					case 'Success_':
+						return t.success(success(e.value));
+				}
+			}
+		},
+		a =>
+			a.foldL<JSONRemoteData_<OL, OR>>(
+				() => ({ type: 'Initial_' }),
+				progress => ({ type: 'Pending_', progress: JSONProgress.encode(progress) }),
+				l => ({ type: 'Failure_', error: leftType.encode(l) }),
+				a => ({ type: 'Success_', value: rightType.encode(a) }),
+			),
+		leftType,
+		rightType,
+	);
+}

--- a/src/remote-data_.ts
+++ b/src/remote-data_.ts
@@ -1,0 +1,1002 @@
+import { constFalse, Function2, Function1, Lazy, toString, Predicate, identity } from 'fp-ts/lib/function';
+import { Monad2 } from 'fp-ts/lib/Monad';
+import { Foldable2 } from 'fp-ts/lib/Foldable';
+import { Alt2 } from 'fp-ts/lib/Alt';
+import { Extend2 } from 'fp-ts/lib/Extend';
+import { sequence, Traversable2 } from 'fp-ts/lib/Traversable';
+import { isNone, none, Option, some } from 'fp-ts/lib/Option';
+import { Either, left, right, isLeft } from 'fp-ts/lib/Either';
+import { Setoid } from 'fp-ts/lib/Setoid';
+
+import { array } from 'fp-ts/lib/Array';
+
+import { HKT, HKT2, Type, Type2, URIS, URIS2 } from 'fp-ts/lib/HKT';
+import { Applicative } from 'fp-ts/lib/Applicative';
+import { Alternative2 } from 'fp-ts/lib/Alternative';
+import { Ord } from 'fp-ts/lib/Ord';
+import { sign } from 'fp-ts/lib/Ordering';
+import { Semigroup } from 'fp-ts/lib/Semigroup';
+import { Monoid } from 'fp-ts/lib/Monoid';
+import { Monoidal2 } from 'fp-ts/lib/Monoidal';
+
+export const URI_ = 'RemoteData_';
+export type URI_ = typeof URI_;
+declare module 'fp-ts/lib/HKT' {
+	interface URI2HKT2<L, A> {
+		RemoteData_: RemoteData_<L, A>;
+	}
+}
+
+export type RemoteProgress_ = {
+	loaded: number;
+	total: Option<number>;
+};
+const concatPendings = <L, A>(a: RemotePending_<L, A>, b: RemotePending_<L, A>): RemoteData_<L, A> => {
+	if (a.progress.isSome() && b.progress.isSome()) {
+		const progressA = a.progress.value;
+		const progressB = b.progress.value;
+		if (progressA.total.isNone() || progressB.total.isNone()) {
+			//tslint:disable no-use-before-declare
+			return progress({
+				loaded: progressA.loaded + progressB.loaded,
+				total: none,
+			});
+			//tslint:enable no-use-before-declare
+		}
+		const totalA = progressA.total.value;
+		const totalB = progressB.total.value;
+		const total = totalA + totalB;
+		const loaded = (progressA.loaded * totalA + progressB.loaded * totalB) / (total * total);
+		//tslint:disable no-use-before-declare
+		return progress({
+			loaded,
+			total: some(total),
+		});
+		//tslint:enable no-use-before-declare
+	}
+	const noA = a.progress.isNone();
+	const noB = b.progress.isNone();
+	if (noA && !noB) {
+		return b;
+	}
+	if (!noA && noB) {
+		return a;
+	}
+	return pending; //tslint:disable-line no-use-before-declare
+};
+
+//tslint:disable-next-line class-name
+export class RemoteInitial_<L, A> {
+	readonly _tag: 'RemoteInitial_' = 'RemoteInitial_';
+	// prettier-ignore
+	readonly '_URI': URI_;
+	// prettier-ignore
+	readonly '_A': A;
+	// prettier-ignore
+	readonly '_L': L;
+
+	/**
+	 * `alt` short for alternative, takes another `RemoteData_`.
+	 * If `this` `RemoteData_` is a `RemoteSuccess_` type then it will be returned.
+	 * If it is a "Left" part then it will return the next `RemoteSuccess_` if it exist.
+	 * If both are "Left" parts then it will return next "Left" part.
+	 *
+	 * For example:
+	 *
+	 * `sucess(1).alt(initial) will return success(1)`
+	 *
+	 * `pending.alt(success(2) will return success(2)`
+	 *
+	 * `failure(new Error('err text')).alt(pending) will return pending`
+	 */
+	alt(fy: RemoteData_<L, A>): RemoteData_<L, A> {
+		return fy;
+	}
+
+	/**
+	 * Similar to `alt`, but lazy: it takes a function which returns `RemoteData_` object.
+	 */
+	altL(fy: Lazy<RemoteData_<L, A>>): RemoteData_<L, A> {
+		return fy();
+	}
+
+	/**
+	 * `ap`, short for "apply". Takes a function `fab` that is in the context of `RemoteData_`,
+	 * and applies that function to this `RemoteData_`'s value.
+	 * If the `RemoteData_` calling `ap` is "Left" part it will return same "Left" part.
+	 * If you pass "Left" part to `ap` as an argument, it will return same "Left" part regardless on `RemoteData_` which calls `ap`.
+	 *
+	 * For example:
+	 *
+	 * `success(1).ap(success(x => x + 1)) will return success(2)`.
+	 *
+	 * `success(1).ap(initial) will return initial`.
+	 *
+	 * `pending.ap(success(x => x+1)) will return pending`.
+	 *
+	 * `failure(new Error('err text')).ap(initial) will return failure.`
+	 */
+	ap<B>(fab: RemoteData_<L, Function1<A, B>>): RemoteData_<L, B> {
+		return fab.isFailure() ? (fab as any) : initial; //tslint:disable-line no-use-before-declare
+	}
+
+	/**
+	 * Takes a function `f` and returns a result of applying it to `RemoteData_` value.
+	 * It's a bit like a `map`, but `f` should returns `RemoteData_<T>` instead of `T` in `map`.
+	 * If this `RemoteData_` is "Left" part, then it will return the same "Left" part.
+	 *
+	 * For example:
+	 *
+	 * `success(1).chain(x => success(x + 1)) will return success(2)`
+	 *
+	 * `success(2).chain(() => pending) will return pending`
+	 *
+	 * `initial.chain(x => success(x)) will return initial`
+	 */
+	chain<B>(f: Function1<A, RemoteData_<L, B>>): RemoteData_<L, B> {
+		return initial; //tslint:disable-line no-use-before-declare
+	}
+
+	/**
+	 * Takes a function `f` and returns a result of applying it to `RemoteData_`.
+	 * It's a bit like a `chain`, but `f` should takes `RemoteData_<T>` instead of returns it, and it should return T instead of takes it.
+	 */
+	extend<B>(f: Function1<RemoteData_<L, A>, B>): RemoteData_<L, B> {
+		return initial; //tslint:disable-line no-use-before-declare
+	}
+
+	/**
+	 * Needed for "unwrap" value from `RemoteData_` "container".
+	 * It applies a function to each case in the data structure.
+	 *
+	 * For example:
+	 *
+	 * `const foldInitial = 'it's initial'
+	 * `const foldPending = 'it's pending'
+	 * `const foldFailure = (err) => 'it's failure'
+	 * `const foldSuccess = (data) => data + 1'
+	 *
+	 * `initial.fold(foldInitial, foldPending, foldFailure, foldSuccess) will return 'it's initial'`
+	 *
+	 * `pending.fold(foldInitial, foldPending, foldFailure, foldSuccess) will return 'it's pending'`
+	 *
+	 * `failure(new Error('error text')).fold(foldInitial, foldPending, foldFailure, foldSuccess) will return 'it's failure'`
+	 *
+	 * `success(21).fold(foldInitial, foldPending, foldFailure, foldSuccess) will return 22`
+	 */
+	fold<B>(initial: B, pending: B, failure: Function1<L, B>, success: Function1<A, B>): B {
+		return initial;
+	}
+
+	/**
+	 * Same as `fold` but lazy: in `initial` and `pending` state it takes a function instead of value.
+	 *
+	 * For example:
+	 *
+	 * `const foldInitial = () => 'it's initial'
+	 * `const foldPending = () => 'it's pending'
+	 *
+	 * rest of example is similar to `fold`
+	 */
+	foldL<B>(
+		initial: Lazy<B>,
+		pending: Function1<Option<RemoteProgress_>, B>,
+		failure: Function1<L, B>,
+		success: Function1<A, B>,
+	): B {
+		return initial();
+	}
+
+	/**
+	 * Same as `getOrElse` but lazy: it pass as an argument a function which returns a default value.
+	 *
+	 * For example:
+	 *
+	 * `some(1).getOrElse(() => 999) will return 1`
+	 *
+	 * `initial.getOrElseValue(() => 999) will return 999`
+	 */
+	getOrElseL(f: Lazy<A>): A {
+		return f();
+	}
+
+	/**
+	 * Takes a function `f`.
+	 * If it maps on `RemoteSuccess_` then it will apply a function to `RemoteData_`'s value
+	 * If it maps on "Left" part then it will return the same "Left" part.
+	 *
+	 * For example:
+	 *
+	 * `success(1).map(x => x + 99) will return success(100)`
+	 *
+	 * `initial.map(x => x + 99) will return initial`
+	 *
+	 * `pending.map(x => x + 99) will return pending`
+	 *
+	 * `failure(new Error('error text')).map(x => x + 99) will return failure(new Error('error text')`
+	 */
+	map<B>(f: Function1<A, B>): RemoteData_<L, B> {
+		return initial; //tslint:disable-line no-use-before-declare
+	}
+
+	/**
+	 * Similar to `map`, but it only map a `RemoteFailure_` ("Left" part where we have some data, so we can map it).
+	 *
+	 * For example:
+	 *
+	 * `success(1).map(x => 'new error text') will return success(1)`
+	 *
+	 * `initial.map(x => 'new error text') will return initial`
+	 *
+	 * `failure(new Error('error text')).map(x => 'new error text') will return failure(new Error('new error text'))`
+	 */
+	mapLeft<M>(f: Function1<L, M>): RemoteData_<M, A> {
+		return initial; //tslint:disable-line no-use-before-declare
+	}
+
+	/**
+	 * Takes a default value as an argument.
+	 * If this `RemoteData_` is "Left" part it will return default value.
+	 * If this `RemoteData_` is `RemoteSuccess_` it will return it's value ("wrapped" value, not default value)
+	 *
+	 * Note: Default value should be the same type as `RemoteData_` (internal) value, if you want to pass different type as default, use `fold` or `foldL`.
+	 *
+	 * For example:
+	 *
+	 * `some(1).getOrElse(999) will return 1`
+	 *
+	 * `initial.getOrElseValue(999) will return 999`
+	 *
+	 */
+	getOrElse(value: A): A {
+		return value;
+	}
+
+	reduce<B>(f: Function2<B, A, B>, b: B): B {
+		return b;
+	}
+
+	/**
+	 * Returns true only if `RemoteData_` is `RemoteInitial_`.
+	 *
+	 */
+	isInitial(): this is RemoteInitial_<L, A> {
+		return true;
+	}
+
+	/**
+	 * Returns true only if `RemoteData_` is `RemotePending_`.
+	 *
+	 */
+	isPending(): this is RemotePending_<L, A> {
+		return false;
+	}
+
+	/**
+	 * Returns true only if `RemoteData_` is `RemoteFailure_`.
+	 *
+	 */
+	isFailure(): this is RemoteFailure_<L, A> {
+		return false;
+	}
+
+	/**
+	 * Returns true only if `RemoteData_` is `RemoteSuccess_`.
+	 *
+	 */
+	isSuccess(): this is RemoteSuccess_<L, A> {
+		return false;
+	}
+
+	/**
+	 * Convert `RemoteData_` to `Option`.
+	 * "Left" part will be converted to `None`.
+	 * `RemoteSuccess_` will be converted to `Some`.
+	 *
+	 * For example:
+	 *
+	 * `success(2).toOption() will return some(2)`
+	 *
+	 * `initial.toOption() will return none`
+	 *
+	 * `pending.toOption() will return none`
+	 *
+	 * `failure(new Error('error text')).toOption() will return none`
+	 */
+	toOption(): Option<A> {
+		return none;
+	}
+
+	/**
+	 * Convert `RemoteData_` to `Either`.
+	 * "Left" part will be converted to `Left<L>`.
+	 * Since `RemoteInitial_` and `RemotePending_` do not have `L` values,
+	 * you must provide a value of type `L` that will be used to construct
+	 * the `Left<L>` for those two cases.
+	 * `RemoteSuccess_` will be converted to `Right<R>`.
+	 *
+	 * For example:
+	 *
+	 * `const iError = new Error('Data not fetched')`
+	 * `const pError = new Error('Data is fetching')`
+	 *
+	 * `success(2).toEither(iError, pError) will return right(2)`
+	 *
+	 * `initial.toEither(iError, pError) will return right(Error('Data not fetched'))`
+	 *
+	 * `pending.toEither(iError, pError) will return right(Error('Data is fetching'))`
+	 *
+	 * `failure(new Error('error text')).toEither(iError, pError) will return right(Error('error text'))`
+	 */
+	toEither(initial: L, pending: L): Either<L, A> {
+		return left(initial);
+	}
+
+	/**
+	 * Like `toEither`, but lazy: it takes functions that return an `L` value
+	 * as arguments instead of an `L` value.
+	 *
+	 * For example:
+	 *
+	 * `const iError = () => new Error('Data not fetched')`
+	 * `const pError = () => new Error('Data is fetching')`
+	 *
+	 * `initial.toEither(iError, pError) will return right(Error('Data not fetched'))`
+	 *
+	 * `pending.toEither(iError, pError) will return right(Error('Data is fetching'))`
+	 */
+	toEitherL(initial: Lazy<L>, pending: Lazy<L>): Either<L, A> {
+		return left(initial());
+	}
+
+	/**
+	 * One more way to fold (unwrap) value from `RemoteData_`.
+	 * "Left" part will return `null`.
+	 * `RemoteSuccess_` will return value.
+	 *
+	 * For example:
+	 *
+	 * `success(2).toNullable() will return 2`
+	 *
+	 * `initial.toNullable() will return null`
+	 *
+	 * `pending.toNullable() will return null`
+	 *
+	 * `failure(new Error('error text)).toNullable() will return null`
+	 *
+	 */
+	toNullable(): A | null {
+		return null;
+	}
+
+	/**
+	 * Returns string representation of `RemoteData_`.
+	 */
+	toString(): string {
+		return 'initial';
+	}
+
+	/**
+	 * Compare values and returns `true` if they are identical, otherwise returns `false`.
+	 * "Left" part will return `false`.
+	 * `RemoteSuccess_` will call `Setoid`'s `equals` method.
+	 *
+	 * If you want to compare `RemoteData_`'s values better use `getSetoid` or `getOrd` helpers.
+	 *
+	 */
+	contains(S: Setoid<A>, a: A): boolean {
+		return false;
+	}
+
+	/**
+	 * Takes a predicate and apply it to `RemoteSuccess_` value.
+	 * "Left" part will return `false`.
+	 */
+	exists(p: Predicate<A>): boolean {
+		return false;
+	}
+
+	/**
+	 * Maps this RemoteFailure error into RemoteSuccess if passed function f return {@link Some} value, otherwise returns self
+	 */
+	recover(f: (error: L) => Option<A>): RemoteData_<L, A> {
+		return this;
+	}
+
+	/**
+	 * Recovers this RemoteFailure also mapping RemoteSuccess case
+	 * @see {@link recover}
+	 */
+	recoverMap<B>(f: (error: L) => Option<B>, g: (value: A) => B): RemoteData_<L, B> {
+		return this as any;
+	}
+}
+
+//tslint:disable-next-line class-name
+export class RemoteFailure_<L, A> {
+	readonly _tag: 'RemoteFailure_' = 'RemoteFailure_';
+	// prettier-ignore
+	readonly '_URI': URI_;
+	// prettier-ignore
+	readonly '_A': A;
+	// prettier-ignore
+	readonly '_L': L;
+
+	constructor(readonly error: L) {}
+
+	alt(fy: RemoteData_<L, A>): RemoteData_<L, A> {
+		return fy;
+	}
+
+	altL(fy: Lazy<RemoteData_<L, A>>): RemoteData_<L, A> {
+		return fy();
+	}
+
+	ap<B>(fab: RemoteData_<L, Function1<A, B>>): RemoteData_<L, B> {
+		return fab.isFailure() ? (fab as any) : (this as any); //tslint:disable-line no-use-before-declare
+	}
+
+	chain<B>(f: Function1<A, RemoteData_<L, B>>): RemoteData_<L, B> {
+		return this as any;
+	}
+
+	extend<B>(f: Function1<RemoteData_<L, A>, B>): RemoteData_<L, B> {
+		return this as any;
+	}
+
+	fold<B>(initial: B, pending: B, failure: Function1<L, B>, success: Function1<A, B>): B {
+		return failure(this.error);
+	}
+
+	foldL<B>(
+		initial: Lazy<B>,
+		pending: Function1<Option<RemoteProgress_>, B>,
+		failure: Function1<L, B>,
+		success: Function1<A, B>,
+	): B {
+		return failure(this.error);
+	}
+
+	getOrElseL(f: Lazy<A>): A {
+		return f();
+	}
+
+	map<B>(f: (a: A) => B): RemoteData_<L, B> {
+		return this as any;
+	}
+
+	mapLeft<M>(f: Function1<L, M>): RemoteData_<M, A> {
+		return failure(f(this.error)); //tslint:disable-line no-use-before-declare
+	}
+
+	getOrElse(value: A): A {
+		return value;
+	}
+
+	reduce<B>(f: Function2<B, A, B>, b: B): B {
+		return b;
+	}
+
+	isInitial(): this is RemoteInitial_<L, A> {
+		return false;
+	}
+
+	isPending(): this is RemotePending_<L, A> {
+		return false;
+	}
+
+	isFailure(): this is RemoteFailure_<L, A> {
+		return true;
+	}
+
+	isSuccess(): this is RemoteSuccess_<L, A> {
+		return false;
+	}
+
+	toOption(): Option<A> {
+		return none;
+	}
+
+	toEither(initial: L, pending: L): Either<L, A> {
+		return left(this.error);
+	}
+
+	toEitherL(initial: Lazy<L>, pending: Lazy<L>): Either<L, A> {
+		return left(this.error);
+	}
+
+	toNullable(): A | null {
+		return null;
+	}
+
+	toString(): string {
+		return `failure(${toString(this.error)})`;
+	}
+
+	contains(S: Setoid<A>, a: A): boolean {
+		return false;
+	}
+
+	exists(p: Predicate<A>): boolean {
+		return false;
+	}
+
+	recover(f: (error: L) => Option<A>): RemoteData_<L, A> {
+		return this.recoverMap(f, identity);
+	}
+
+	recoverMap<B>(f: (error: L) => Option<B>, g: (value: A) => B): RemoteData_<L, B> {
+		return f(this.error).fold(this as any, success); //tslint:disable-line no-use-before-declare
+	}
+}
+
+//tslint:disable-next-line class-name
+export class RemoteSuccess_<L, A> {
+	readonly _tag: 'RemoteSuccess_' = 'RemoteSuccess_';
+	// prettier-ignore
+	readonly '_URI': URI_;
+	// prettier-ignore
+	readonly '_A': A;
+	// prettier-ignore
+	readonly '_L': L;
+
+	constructor(readonly value: A) {}
+
+	alt(fy: RemoteData_<L, A>): RemoteData_<L, A> {
+		return this;
+	}
+
+	altL(fy: Lazy<RemoteData_<L, A>>): RemoteData_<L, A> {
+		return this;
+	}
+
+	ap<B>(fab: RemoteData_<L, Function1<A, B>>): RemoteData_<L, B> {
+		return fab.fold(initial, fab, () => fab as any, value => this.map(value)); //tslint:disable-line no-use-before-declare
+	}
+
+	chain<B>(f: Function1<A, RemoteData_<L, B>>): RemoteData_<L, B> {
+		return f(this.value);
+	}
+
+	extend<B>(f: Function1<RemoteData_<L, A>, B>): RemoteData_<L, B> {
+		return of(f(this)); //tslint:disable-line no-use-before-declare
+	}
+
+	fold<B>(initial: B, pending: B, failure: Function1<L, B>, success: Function1<A, B>): B {
+		return success(this.value);
+	}
+
+	foldL<B>(
+		initial: Lazy<B>,
+		pending: Function1<Option<RemoteProgress_>, B>,
+		failure: Function1<L, B>,
+		success: Function1<A, B>,
+	): B {
+		return success(this.value);
+	}
+
+	getOrElseL(f: Lazy<A>): A {
+		return this.value;
+	}
+
+	map<B>(f: Function1<A, B>): RemoteData_<L, B> {
+		return of(f(this.value)); //tslint:disable-line no-use-before-declare
+	}
+
+	mapLeft<M>(f: Function1<L, M>): RemoteData_<M, A> {
+		return this as any;
+	}
+
+	getOrElse(value: A): A {
+		return this.value;
+	}
+
+	reduce<B>(f: Function2<B, A, B>, b: B): B {
+		return f(b, this.value);
+	}
+
+	isInitial(): this is RemoteInitial_<L, A> {
+		return false;
+	}
+
+	isPending(): this is RemotePending_<L, A> {
+		return false;
+	}
+
+	isFailure(): this is RemoteFailure_<L, A> {
+		return false;
+	}
+
+	isSuccess(): this is RemoteSuccess_<L, A> {
+		return true;
+	}
+
+	toOption(): Option<A> {
+		return some(this.value);
+	}
+
+	toEither(initial: L, pending: L): Either<L, A> {
+		return right(this.value);
+	}
+
+	toEitherL(initial: Lazy<L>, pending: Lazy<L>): Either<L, A> {
+		return right(this.value);
+	}
+
+	toNullable(): A | null {
+		return this.value;
+	}
+
+	toString(): string {
+		return `success(${toString(this.value)})`;
+	}
+
+	contains(S: Setoid<A>, a: A): boolean {
+		return S.equals(this.value, a);
+	}
+
+	exists(p: Predicate<A>): boolean {
+		return p(this.value);
+	}
+
+	recover(f: (error: L) => Option<A>): RemoteData_<L, A> {
+		return this;
+	}
+
+	recoverMap<B>(f: (error: L) => Option<B>, g: (value: A) => B): RemoteData_<L, B> {
+		return this.map(g);
+	}
+}
+
+//tslint:disable-next-line class-name
+export class RemotePending_<L, A> {
+	readonly _tag: 'RemotePending_' = 'RemotePending_';
+	// prettier-ignore
+	readonly '_URI': URI_;
+	// prettier-ignore
+	readonly '_A': A;
+	// prettier-ignore
+	readonly '_L': L;
+
+	constructor(readonly progress: Option<RemoteProgress_> = none) {}
+
+	alt(fy: RemoteData_<L, A>): RemoteData_<L, A> {
+		return fy;
+	}
+
+	altL(fy: Lazy<RemoteData_<L, A>>): RemoteData_<L, A> {
+		return fy();
+	}
+
+	ap<B>(fab: RemoteData_<L, Function1<A, B>>): RemoteData_<L, B> {
+		return fab.fold(
+			initial, //tslint:disable-line no-use-before-declare
+			fab.isPending() ? (concatPendings(this, fab as any) as any) : this,
+			() => fab,
+			() => this,
+		);
+	}
+
+	chain<B>(f: Function1<A, RemoteData_<L, B>>): RemoteData_<L, B> {
+		return pending; //tslint:disable-line no-use-before-declare
+	}
+
+	extend<B>(f: Function1<RemoteData_<L, A>, B>): RemoteData_<L, B> {
+		return pending; //tslint:disable-line no-use-before-declare
+	}
+
+	fold<B>(initial: B, pending: B, failure: Function1<L, B>, success: Function1<A, B>): B {
+		return pending;
+	}
+
+	foldL<B>(
+		initial: Lazy<B>,
+		pending: Function1<Option<RemoteProgress_>, B>,
+		failure: Function1<L, B>,
+		success: Function1<A, B>,
+	): B {
+		return pending(this.progress);
+	}
+
+	getOrElseL(f: Lazy<A>): A {
+		return f();
+	}
+
+	map<B>(f: Function1<A, B>): RemoteData_<L, B> {
+		return this as any;
+	}
+
+	mapLeft<M>(f: Function1<L, M>): RemoteData_<M, A> {
+		return pending; //tslint:disable-line no-use-before-declare
+	}
+
+	getOrElse(value: A): A {
+		return value;
+	}
+
+	reduce<B>(f: Function2<B, A, B>, b: B): B {
+		return b;
+	}
+
+	isInitial(): this is RemoteInitial_<L, A> {
+		return false;
+	}
+
+	isPending(): this is RemotePending_<L, A> {
+		return true;
+	}
+
+	isFailure(): this is RemoteFailure_<L, A> {
+		return false;
+	}
+
+	isSuccess(): this is RemoteSuccess_<L, A> {
+		return false;
+	}
+
+	toOption(): Option<A> {
+		return none;
+	}
+
+	toEither(initial: L, pending: L): Either<L, A> {
+		return left(pending);
+	}
+
+	toEitherL(initial: Lazy<L>, pending: Lazy<L>): Either<L, A> {
+		return left(pending());
+	}
+
+	toNullable(): A | null {
+		return null;
+	}
+
+	toString(): string {
+		return 'pending';
+	}
+
+	contains(S: Setoid<A>, a: A): boolean {
+		return false;
+	}
+
+	exists(p: Predicate<A>): boolean {
+		return false;
+	}
+
+	recover(f: (error: L) => Option<A>): RemoteData_<L, A> {
+		return this;
+	}
+
+	recoverMap<B>(f: (error: L) => Option<B>, g: (value: A) => B): RemoteData_<L, B> {
+		return this as any;
+	}
+}
+
+/**
+ * Represents a value of one of four possible types (a disjoint union)
+ *
+ * An instance of `RemoteData_` is either an instance of `RemoteInitial_`, `RemotePending_`, `RemoteFailure_` or `RemoteSuccess_`
+ *
+ * A common use of `RemoteData_` is as an alternative to `Either` or `Option` supporting initial and pending states (fits best with [RXJS]{@link https://github.com/ReactiveX/rxjs/}).
+ *
+ * Note: `RemoteInitial_`, `RemotePending_` and `RemoteFailure_` are commonly called "Left" part in jsDoc.
+ *
+ * @see https://medium.com/@gcanti/slaying-a-ui-antipattern-with-flow-5eed0cfb627b
+ *
+ */
+export type RemoteData_<L, A> =
+	| RemoteInitial_<L, A>
+	| RemoteFailure_<L, A>
+	| RemoteSuccess_<L, A>
+	| RemotePending_<L, A>;
+
+//Monad
+const of = <L, A>(value: A): RemoteSuccess_<L, A> => new RemoteSuccess_(value);
+const ap = <L, A, B>(fab: RemoteData_<L, Function1<A, B>>, fa: RemoteData_<L, A>): RemoteData_<L, B> => fa.ap(fab);
+const map = <L, A, B>(fa: RemoteData_<L, A>, f: Function1<A, B>): RemoteData_<L, B> => fa.map(f);
+const chain = <L, A, B>(fa: RemoteData_<L, A>, f: Function1<A, RemoteData_<L, B>>): RemoteData_<L, B> => fa.chain(f);
+
+//Foldable
+const reduce = <L, A, B>(fa: RemoteData_<L, A>, b: B, f: Function2<B, A, B>): B => fa.reduce(f, b);
+
+//Traversable
+function traverse<F extends URIS2>(
+	F: Applicative<F>,
+): <L, A, B>(ta: RemoteData_<L, A>, f: Function1<A, HKT2<F, L, B>>) => Type2<F, L, RemoteData_<L, B>>;
+function traverse<F extends URIS>(
+	F: Applicative<F>,
+): <L, A, B>(ta: RemoteData_<L, A>, f: Function1<A, HKT<F, B>>) => Type<F, RemoteData_<L, B>>;
+function traverse<F>(
+	F: Applicative<F>,
+): <L, A, B>(ta: RemoteData_<L, A>, f: Function1<A, HKT<F, B>>) => HKT<F, RemoteData_<L, B>>;
+function traverse<F>(
+	F: Applicative<F>,
+): <L, A, B>(ta: RemoteData_<L, A>, f: Function1<A, HKT<F, B>>) => HKT<F, RemoteData_<L, B>> {
+	return (ta, f) => {
+		if (ta.isSuccess()) {
+			return F.map(f(ta.value), of);
+		} else {
+			return F.of(ta as any);
+		}
+	};
+}
+
+//Alt
+const alt = <L, A>(fx: RemoteData_<L, A>, fy: RemoteData_<L, A>): RemoteData_<L, A> => fx.alt(fy);
+
+//Extend
+const extend = <L, A, B>(fla: RemoteData_<L, A>, f: Function1<RemoteData_<L, A>, B>): RemoteData_<L, B> =>
+	fla.extend(f);
+
+//constructors
+export const failure = <L, A>(error: L): RemoteData_<L, A> => new RemoteFailure_(error);
+export const success: <L, A>(value: A) => RemoteData_<L, A> = of;
+export const pending: RemoteData_<never, never> = new RemotePending_<never, never>();
+export const progress = <L, A>(progress: RemoteProgress_): RemoteData_<L, A> => new RemotePending_(some(progress));
+export const initial: RemoteData_<never, never> = new RemoteInitial_<never, never>();
+
+//Alternative
+const zero = <L, A>(): RemoteData_<L, A> => initial;
+
+//filters
+export const isFailure = <L, A>(data: RemoteData_<L, A>): data is RemoteFailure_<L, A> => data.isFailure();
+export const isSuccess = <L, A>(data: RemoteData_<L, A>): data is RemoteSuccess_<L, A> => data.isSuccess();
+export const isPending = <L, A>(data: RemoteData_<L, A>): data is RemotePending_<L, A> => data.isPending();
+export const isInitial = <L, A>(data: RemoteData_<L, A>): data is RemoteInitial_<L, A> => data.isInitial();
+
+//Monoidal
+const unit = <L, A>(): RemoteData_<L, A> => initial;
+const mult = <L, A, B>(fa: RemoteData_<L, A>, fb: RemoteData_<L, B>): RemoteData_<L, [A, B]> => combine(fa, fb);
+
+//Setoid
+export const getSetoid = <L, A>(SL: Setoid<L>, SA: Setoid<A>): Setoid<RemoteData_<L, A>> => {
+	return {
+		equals: (x, y) =>
+			x.foldL(
+				() => y.isInitial(),
+				() => y.isPending(),
+				xError => y.foldL(constFalse, constFalse, yError => SL.equals(xError, yError), constFalse),
+				ax => y.foldL(constFalse, constFalse, constFalse, ay => SA.equals(ax, ay)),
+			),
+	};
+};
+
+//Ord
+export const getOrd = <L, A>(OL: Ord<L>, OA: Ord<A>): Ord<RemoteData_<L, A>> => {
+	return {
+		...getSetoid(OL, OA),
+		compare: (x, y) =>
+			sign(
+				x.foldL(
+					() => y.fold(0, -1, () => -1, () => -1),
+					() => y.fold(1, 0, () => -1, () => -1),
+					xError => y.fold(1, 1, yError => OL.compare(xError, yError), () => -1),
+					xValue => y.fold(1, 1, () => 1, yValue => OA.compare(xValue, yValue)),
+				),
+			),
+	};
+};
+
+//Semigroup
+export const getSemigroup = <L, A>(SL: Semigroup<L>, SA: Semigroup<A>): Semigroup<RemoteData_<L, A>> => {
+	return {
+		concat: (x, y) => {
+			return x.foldL(
+				() => y.fold(y, y, () => y, () => y),
+				() => y.foldL(() => x, () => concatPendings(x as any, y as any), () => y, () => y),
+
+				xError => y.fold(x, x, yError => failure(SL.concat(xError, yError)), () => y),
+				xValue => y.fold(x, x, () => x, yValue => success(SA.concat(xValue, yValue))),
+			);
+		},
+	};
+};
+
+//Monoid
+export const getMonoid = <L, A>(SL: Semigroup<L>, SA: Semigroup<A>): Monoid<RemoteData_<L, A>> => {
+	return {
+		...getSemigroup(SL, SA),
+		empty: initial,
+	};
+};
+
+export function fromOption<L, A>(option: Option<A>, error: Lazy<L>): RemoteData_<L, A> {
+	if (isNone(option)) {
+		return failure(error());
+	} else {
+		return success(option.value);
+	}
+}
+
+export function fromEither<L, A>(either: Either<L, A>): RemoteData_<L, A> {
+	if (isLeft(either)) {
+		return failure(either.value);
+	} else {
+		return success(either.value);
+	}
+}
+
+export function fromPredicate<L, A>(
+	predicate: Predicate<A>,
+	whenFalse: Function1<A, L>,
+): Function1<A, RemoteData_<L, A>> {
+	return a => (predicate(a) ? success(a) : failure(whenFalse(a)));
+}
+
+export function fromProgressEvent<L, A>(event: ProgressEvent): RemoteData_<L, A> {
+	return progress({
+		loaded: event.loaded,
+		total: event.lengthComputable ? some(event.total) : none,
+	});
+}
+
+//instance
+export const remoteData: Monad2<URI_> &
+	Foldable2<URI_> &
+	Traversable2<URI_> &
+	Alt2<URI_> &
+	Extend2<URI_> &
+	Alternative2<URI_> &
+	Monoidal2<URI_> = {
+	//HKT
+	URI: URI_,
+
+	//Monad
+	of,
+	ap,
+	map,
+	chain,
+
+	//Foldable
+	reduce,
+
+	//Traversable
+	traverse,
+
+	//Alt
+	alt,
+
+	//Alternative
+	zero,
+
+	//Extend
+	extend,
+
+	//Monoidal
+	unit,
+	mult,
+};
+
+export function combine<A, L>(a: RemoteData_<L, A>): RemoteData_<L, [A]>;
+export function combine<A, B, L>(a: RemoteData_<L, A>, b: RemoteData_<L, B>): RemoteData_<L, [A, B]>;
+export function combine<A, B, C, L>(
+	a: RemoteData_<L, A>,
+	b: RemoteData_<L, B>,
+	c: RemoteData_<L, C>,
+): RemoteData_<L, [A, B, C]>;
+export function combine<A, B, C, D, L>(
+	a: RemoteData_<L, A>,
+	b: RemoteData_<L, B>,
+	c: RemoteData_<L, C>,
+	d: RemoteData_<L, D>,
+): RemoteData_<L, [A, B, C, D]>;
+export function combine<A, B, C, D, E, L>(
+	a: RemoteData_<L, A>,
+	b: RemoteData_<L, B>,
+	c: RemoteData_<L, C>,
+	d: RemoteData_<L, D>,
+	e: RemoteData_<L, E>,
+): RemoteData_<L, [A, B, C, D, E]>;
+export function combine<A, B, C, D, E, F, L>(
+	a: RemoteData_<L, A>,
+	b: RemoteData_<L, B>,
+	c: RemoteData_<L, C>,
+	d: RemoteData_<L, D>,
+	e: RemoteData_<L, E>,
+	f: RemoteData_<L, F>,
+): RemoteData_<L, [A, B, C, D, E, F]>;
+export function combine<T, L>(...list: RemoteData_<L, T>[]): RemoteData_<L, T[]> {
+	if (list.length === 0) {
+		return of([]);
+	}
+	return sequence(remoteData, array)(list);
+}


### PR DESCRIPTION
The conversation in https://github.com/devex-web-frontend/remote-data-ts/issues/26 seemed to be stalling, so I took the initiative to create this PR to continue the discussion. Sorry for the long post, but I'm trying to be as detailed as possible. 😄 

At first, I considered just exporting an alternate set of type class instances under a different name, such as `export remoteData_ = ...` or `export remoteDataFailFast = ...` which used a separate, new implementation for `Apply (the `ap` function), but, after thinking about it more, I realized that I would also want the class methods for each member of the RemoteData union type to use these alternate `ap` implementations.

Personally, I'm not a huge fan of method chaining. I prefer just using standalone functions, but many people, including people I work with, tend to just use the method chaining approach when working with `fp-ts` & its related libraries. This is why I don't think that standalone export with the new functionality would be a good enough solution... everyone would always have to remember not to use method chaining, because the `ap` implementation on the classes would provide the wrong behavior.

Typically, I think providing alternate type class instances in that way would be fine, but, in this case, I think that this is a rather important difference for how this data type functions and deserves its own implementation. I actually believe it is the default behavior that most people would want, and it's the behavior other implementations have decided to use, as seen in PureScript's RemoteData library (https://github.com/krisajenkins/purescript-remotedata/blob/master/src/Network/RemoteData.purs#L56-L65), which is written by the same person who initially created RemoteData for Elm.

This is why I decided to create all new versions in their own independent files. I decided to add a `_` suffix to all types in these files to create unique types, because not doing this caused problems with the TS compiler running out of memory and crashing. I went with `_` to try to mimic what Haskell/PureScript do with the `'` (prime) character, because that character is not valid in variable names in JS/TS. I also added this `_` suffix to any references which exist as both values and types, such as `URI_` and string literals, like `Failure_`. However, I didn't change the names of any exported functions, because they can be exported from a different directory.

Here are the 4 implementations for `ap` that I went with...

RemoteInitial_:
```ts
ap<B>(fab: RemoteData_<L, Function1<A, B>>): RemoteData_<L, B> {
	return fab.isFailure() ? (fab as any) : initial; //tslint:disable-line no-use-before-declare
}
```

RemoteFailure_
```ts
ap<B>(fab: RemoteData_<L, Function1<A, B>>): RemoteData_<L, B> {
	return fab.isFailure() ? (fab as any) : (this as any); //tslint:disable-line no-use-before-declare
}
```

RemoteSuccess_
```ts
ap<B>(fab: RemoteData_<L, Function1<A, B>>): RemoteData_<L, B> {
	return fab.fold(initial, fab, () => fab as any, value => this.map(value)); //tslint:disable-line no-use-before-declare
}
```

RemotePending_
```ts
ap<B>(fab: RemoteData_<L, Function1<A, B>>): RemoteData_<L, B> {
	return fab.fold(
		initial, //tslint:disable-line no-use-before-declare
		fab.isPending() ? (concatPendings(this, fab as any) as any) : this,
		() => fab,
		() => this,
	);
}
```

I tried to duplicate the logic expressed in the previously linked PureScript implementation in the above. I believe all 4 are correct, but I would appreciate a a second pair of eyes looking them over to make sure I didn't make any mistakes. 😃 

Also, for further clarity, @quicksnap & I both work at the same company (SimSpace), and we want to use this library in production there. He had already started using the library before we noticed the `ap` implementation is different than what we want, and, since then, I have been holding off on using it until seeing what happens with https://github.com/devex-web-frontend/remote-data-ts/issues/26 (and, now, this PR).

I think the approach I took with this PR is, overall, the best solution for users of the library. However, I do recognize the burden of needing to maintain these alternate files, and I would understand if you don't want to, but I am willing to help maintain this library... but, I could also just fork the library either under my personal account or, possibly, under the SimSpace organization account, to host this alternate implementation, if everyone thinks that would be the best approach instead.

Side note: I noticed that the library is still using `typescript@2.8.1`, and there are some errors in a few files when trying to use newer versions of TypeScript. For this reason, I chose to make this PR use that version.... to keep things consistent with the original files. However, I think it would be nice to upgrade the library (as a whole) to the current version of TypeScript and fix any associated errors in the near future. I would also be willing to help with this.

Please, let me know what you think. I would like solve this here & help maintain this library, rather than fork it, if possible.