### PR TITLE
Fail fast ap, TS/fp-ts/io-ts upgrade, Traversable2v, Bifunctor

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1144,9 +1144,9 @@
       }
     },
     "commander": {
-      "version": "2.14.1",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.14.1.tgz",
-      "integrity": "sha512-+YR16o3rK53SmWHU3rEM3tPAh2rwb1yPcQX5irVn7mb0gXbwuCCrnkbV5+PBfETdfg1vui07nM6PCG1zndcjQw==",
+      "version": "2.19.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.19.0.tgz",
+      "integrity": "sha512-6tvAOO+D6OENvRAh524Dh9jcfKTYDQAqvqezbCW82xj5X0pSrcpxtvRKHLG0yBY6SD7PSDrJaj+0AiOcKVd1Xg==",
       "dev": true
     },
     "compare-func": {
@@ -1967,10 +1967,9 @@
       }
     },
     "fp-ts": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/fp-ts/-/fp-ts-1.2.0.tgz",
-      "integrity": "sha512-GHUrakKieiz7BWL7eX9G7UMawnaeGSJ1HbZY5t+BbgvzhzgNCT2SXtfqrIl0pRZHkp/oiysdWLMoIxYVlXy66g==",
-      "dev": true
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/fp-ts/-/fp-ts-1.13.0.tgz",
+      "integrity": "sha512-QDPtCkuLay+dX3zinnvt0ER+j8mdWZZSpM//DIY3GycgwUTDPBKFD7CxX5DU/mIDstcWqGuuUSrMNtB6MWluCQ=="
     },
     "fragment-cache": {
       "version": "0.2.1",
@@ -3049,10 +3048,9 @@
       "dev": true
     },
     "io-ts": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/io-ts/-/io-ts-1.3.1.tgz",
-      "integrity": "sha512-PqTcX4ojXogRZRk86o7gltg9996DtKrxN2qjv9OOjBYHI0DSEJtwiJBoK682To1YE7ONNNaqwd9phN4WF3nomQ==",
-      "dev": true,
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/io-ts/-/io-ts-1.7.0.tgz",
+      "integrity": "sha512-NFXDhjUNW+JKzNIkSeHTUUMXn+2QVoPg33qTIcoS7eDycupoeeeMqgmqlT7EiIe4n5w31Dc1uUrhg7Rt0Kf7xA==",
       "requires": {
         "fp-ts": "^1.0.0"
       }
@@ -3061,7 +3059,6 @@
       "version": "0.3.14",
       "resolved": "https://registry.npmjs.org/io-ts-types/-/io-ts-types-0.3.14.tgz",
       "integrity": "sha512-hEUo+VpS0EXLji14CON7f/ThuLMExaA5kWfW6LIM9gC+X/INTxwLt3GYKkKQc6Fx0snM9xt/QDXd5BPjeXE1RQ==",
-      "dev": true,
       "requires": {
         "fp-ts": "^1.0.0",
         "io-ts": "^1.1.4",
@@ -4884,7 +4881,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/monocle-ts/-/monocle-ts-1.3.0.tgz",
       "integrity": "sha512-oQrsdhh8ut2zRljic2y6EjjWs/NsUj2vDpEY1tLTTo3jE9WS70JOO72HzOY0lWkmgDRsu29pvDbE1aBD8LBkOA==",
-      "dev": true,
       "requires": {
         "fp-ts": "^1.0.0"
       }
@@ -4951,7 +4947,6 @@
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/newtype-ts/-/newtype-ts-0.2.1.tgz",
       "integrity": "sha512-Gnch+o9P/7RgKdkwx5mqWr3iR+Sxxvk2mykPaH93Y9WDhnVQ/ojdOoAGb9O/qHjnYMqJYW0xee9uNebdfpyCLg==",
-      "dev": true,
       "requires": {
         "fp-ts": "^1.0.0",
         "monocle-ts": "^1.0.0"
@@ -5652,12 +5647,20 @@
       "dev": true
     },
     "resolve": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.5.0.tgz",
-      "integrity": "sha512-hgoSGrc3pjzAPHNBg+KnFcK2HwlHTs/YrAGUr6qgTVUZmXv1UEXXl0bZNBKMA9fud6lRYFdPGz0xXxycPzmmiw==",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.10.0.tgz",
+      "integrity": "sha512-3sUr9aq5OfSg2S9pNtPA9hL1FVEAjvfOC4leW0SNf/mpnaakz2a9femSd6LqAww2RaFctwyf1lCqnTHuF1rxDg==",
       "dev": true,
       "requires": {
-        "path-parse": "^1.0.5"
+        "path-parse": "^1.0.6"
+      },
+      "dependencies": {
+        "path-parse": {
+          "version": "1.0.6",
+          "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
+          "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
+          "dev": true
+        }
       }
     },
     "resolve-cwd": {
@@ -6683,13 +6686,12 @@
     "tslib": {
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.0.tgz",
-      "integrity": "sha512-f/qGG2tUkrISBlQZEjEqoZ3B2+npJjIf04H1wuAv9iA8i04Icp+61KRXxFdha22670NJopsZCIjhC3SnjPRKrQ==",
-      "dev": true
+      "integrity": "sha512-f/qGG2tUkrISBlQZEjEqoZ3B2+npJjIf04H1wuAv9iA8i04Icp+61KRXxFdha22670NJopsZCIjhC3SnjPRKrQ=="
     },
     "tslint": {
-      "version": "5.9.1",
-      "resolved": "https://registry.npmjs.org/tslint/-/tslint-5.9.1.tgz",
-      "integrity": "sha1-ElX4ej/1frCw4fDmEKi0dIBGya4=",
+      "version": "5.12.1",
+      "resolved": "https://registry.npmjs.org/tslint/-/tslint-5.12.1.tgz",
+      "integrity": "sha512-sfodBHOucFg6egff8d1BvuofoOQ/nOeYNfbp7LDlKBcLNrL3lmS5zoiDGyOMdT7YsEXAwWpTdAHwOGOc8eRZAw==",
       "dev": true,
       "requires": {
         "babel-code-frame": "^6.22.0",
@@ -6703,7 +6705,7 @@
         "resolve": "^1.3.2",
         "semver": "^5.3.0",
         "tslib": "^1.8.0",
-        "tsutils": "^2.12.1"
+        "tsutils": "^2.27.2"
       }
     },
     "tslint-config-prettier": {
@@ -6723,9 +6725,9 @@
       }
     },
     "tsutils": {
-      "version": "2.21.0",
-      "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-2.21.0.tgz",
-      "integrity": "sha512-zlOHTYtTwvTiKxUyAU8wiKzPpAgwZrGjb7AY18VUlxuCgBiTMVorIl5HjrCT8V64Hm34RI1BZITJMVQpBLMxVg==",
+      "version": "2.29.0",
+      "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-2.29.0.tgz",
+      "integrity": "sha512-g5JVHCIJwzfISaXpXE1qvNalca5Jwob6FjI4AoPlqMusJ6ftFE7IkkFoMhVLRgK+4Kx3gkzb8UZK5t5yTTvEmA==",
       "dev": true,
       "requires": {
         "tslib": "^1.8.1"
@@ -6756,9 +6758,9 @@
       }
     },
     "typescript": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.8.1.tgz",
-      "integrity": "sha512-Ao/f6d/4EPLq0YwzsQz8iXflezpTkQzqAyenTiw4kCUGr1uPiFLC3+fZ+gMZz6eeI/qdRUqvC+HxIJzUAzEFdg==",
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.2.4.tgz",
+      "integrity": "sha512-0RNDbSdEokBeEAkgNbxJ+BLwSManFy9TeXz8uW+48j/xhEXv1ePME60olyzw2XzUqUBNAYFeJadIqAgNqIACwg==",
       "dev": true
     },
     "uglify-js": {

--- a/package.json
+++ b/package.json
@@ -24,14 +24,14 @@
     "jest-cli": "^23.6.0",
     "prettier": "^1.10.2",
     "ts-jest": "^23.10.4",
-    "tslint": "^5.9.1",
+    "tslint": "^5.12.1",
     "tslint-config-prettier": "^1.7.0",
     "tslint-plugin-prettier": "^1.3.0",
-    "typescript": "^2.8.1"
+    "typescript": "^3.2.4"
   },
   "dependencies": {
-    "fp-ts": "^1.2.0",
-    "io-ts": "^1.3.1",
+    "fp-ts": "^1.13.0",
+    "io-ts": "^1.7.0",
     "io-ts-types": "^0.3.14",
     "tslib": "^1.9.0"
   },

--- a/src/remote-data.ts
+++ b/src/remote-data.ts
@@ -828,25 +828,12 @@ const traverse = <F>(F: Applicative<F>) => <L, A, B>(
 ): HKT<F, RemoteData<L, B>> => {
 	if (ta.isSuccess()) {
 		return F.map<B, RemoteData<L, B>>(f(ta.value), of);
-	} else if (ta.isFailure()) {
-		return F.of((ta as unknown) as RemoteFailure<L, B>);
-	} else if (ta.isInitial()) {
-		return F.of((ta as unknown) as RemoteInitial<L, B>);
 	} else {
-		return F.of((ta as unknown) as RemotePending<L, B>);
+		return F.of((ta as unknown) as RemoteFailure<L, B> | RemoteInitial<L, B> | RemotePending<L, B>);
 	}
 };
-const sequence = <F>(F: Applicative<F>) => <L, A>(ta: RemoteData<L, HKT<F, A>>): HKT<F, RemoteData<L, A>> => {
-	if (ta.isSuccess()) {
-		return F.map<A, RemoteData<L, A>>(ta.value, of);
-	} else if (ta.isFailure()) {
-		return F.of((ta as unknown) as RemoteFailure<L, A>);
-	} else if (ta.isInitial()) {
-		return F.of((ta as unknown) as RemoteInitial<L, A>);
-	} else {
-		return F.of((ta as unknown) as RemotePending<L, A>);
-	}
-};
+const sequence = <F>(F: Applicative<F>) => <L, A>(ta: RemoteData<L, HKT<F, A>>): HKT<F, RemoteData<L, A>> =>
+	traverse(F)(ta, identity);
 
 //Bifunctor
 const bimap = <L, V, A, B>(fla: RemoteData<L, A>, f: (u: L) => V, g: (a: A) => B): RemoteData<V, B> => {


### PR DESCRIPTION
Okay, here's the new PR. I ended up just tackling all of the previously mentioned things at one time. I figured that this would be the best way to handle this since changing `ap` to be failure-biased ("fail-fast") was a breaking change. In other words, if we're going to do a breaking change, we might as well do all of these other things at the same time instead of staggering them across separate updates.

This PR makes the following changes:

- Changes the `ap` method implementations of each of the members of the `RemoteData` tagged union. These new `ap` implementations support a fail-fast approach, where a single failure takes precedence over the other possible states of a RemoteData request. The logic is modeled after the `apply` logic in PureScript's RemoteData library, which can be viewed here: https://github.com/krisajenkins/purescript-remotedata/blob/master/src/Network/RemoteData.purs#L56-L65
- Updated TypeScript, tslint, fp-ts, io-ts, etc. to their latest versions
- Removed all `any` usage in favor of `unknown` + explicit type assertions to try to make the code a little bit safer & to make the logic a little easier to follow while reading
- Renamed `initial`, `pending`, `failure`, & `success` function params to follow the latest naming convention in `fp-ts`: `onInitial`, `onPending`, `onFailure`, & `onSuccess`. Doing this avoids overwriting the outer scope variables with the same names (sometimes referred to as "shadowed variables"), which prevents accidentally making mistakes based on scoping
- Migrated from the deprecated `Traversable` type class to the newer `Traversable2v` type class. `Traversable2v` includes `sequence` and extends `Foldable2v`, which adds `foldMap` and `foldr`. I implemented all of these things and simplified the definition for `traverse`. I believe all of my implementations here are correct, but we should look them over carefully to make sure before merging. In particular, I want to draw attention to `sequence` and `traverse` to make sure those are right. Is `F.of(ta)` the implementation we want for all "Left" cases? Should RemoteFailure be treated the same as RemotePending & RemoteInitial? I followed the existing logic from the previously defined `traverse` function, but I'm not 100% sure that this is what we want.
- Added a `Bifunctor` type class instance which allows you to map over both `RemoteFailure` & `RemoteSuccess` simultaneously.

NOTE: In the `remote-data.spec.ts` tests file, I had to stop using the `.apply` style of testing with the `combine` function due to a breaking change in TypeScript 3.2. It always used the last overload signature and was causing errors. You can find more information about that here: https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-2.html

```
Since the stricter checks may uncover previously unreported errors, this is a breaking change in --strict mode.

Additionally, another caveat of this new functionality is that due to certain limitations, bind, call, and apply can’t yet fully model generic functions or functions that have overloads. When using these methods on a generic function, type parameters will be substituted with the empty object type ({}), and when used on a function with overloads, only the last overload will ever be modeled.
```
